### PR TITLE
feat: adds VS Code settings for ESLint monorepo support

### DIFF
--- a/.stackgenrc.ts
+++ b/.stackgenrc.ts
@@ -1,4 +1,4 @@
-import { Bindings, ManifestEntry, PackageDependency, PackageDependencyType, Project, SemanticReleaseSupport, YarnMonoWorkspace, YarnProject } from "@stackgen/core";
+import { Bindings, JsonFile, ManifestEntry, PackageDependency, PackageDependencyType, Project, SemanticReleaseSupport, YarnMonoWorkspace, YarnProject } from "@stackgen/core";
 
 function workspaceDependency (pkg: string) {
   return {
@@ -130,6 +130,7 @@ new YarnProject(workspace, "cli", {
   },
 });
 
+const eslintWorkingDirectories: string[] = []
 
 Bindings
   .of(workspace)
@@ -145,6 +146,15 @@ Bindings
         compile: 'tsup ./index.ts',
       }
     })
+
+    eslintWorkingDirectories.push(`.${project.projectPath}`)
+})
+
+new JsonFile(workspace.defaultProject, 'VsCodeSettings', {
+  filePath: '.vscode/settings.json',
+  fields: {
+    'eslint.workingDirectories': eslintWorkingDirectories.sort()
+  }
 })
 
 export default workspace;

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "eslint.workingDirectories": [
+    "./packages/cli",
+    "./packages/core"
+  ]
+}

--- a/packages/core/L3/nodejs/project/YarnMonoWorkspace.ts
+++ b/packages/core/L3/nodejs/project/YarnMonoWorkspace.ts
@@ -1,5 +1,5 @@
 import { Construct } from "constructs";
-import { LifeCycle, LifeCycleStage, Project } from "../../../L1";
+import { IProject, LifeCycle, LifeCycleStage, Project } from "../../../L1";
 import { ManifestEntry } from "../../../L2";
 import { NodeProject } from "./NodeProject";
 import { NodeWorkspaceProps } from "./NodeWorkspace";
@@ -13,10 +13,16 @@ export interface YarnMonoWorkspaceProps extends Omit<YarnProjectProps, "packageN
  * children of this project.
  */
 export class YarnMonoWorkspace extends YarnWorkspace {
+  /**
+   * Default (root) project of the monorepo workspace.
+   */
+  public defaultProject: IProject;
+
   constructor(props?: YarnMonoWorkspaceProps) {
     super(props);
 
     const defaultProject = new YarnProject(this, "Default", { ...props, name: props?.name ?? "workspace" });
+    this.defaultProject = defaultProject;
 
     LifeCycle.implement(this);
     LifeCycle.of(this).on(LifeCycleStage.BEFORE_SYNTH, () => {


### PR DESCRIPTION
1. Exposes a prop for the default (root) project (aka package) of the workspace.

2. Add support for ESLint monorepo config in VS Code. See https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint#mono-repository-setup

---

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/StackBakery/stackgen/blob/master/CONTRIBUTING.md)

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
