### PR TITLE
feat: adds `exports` to `package.json`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,7 @@
     "email": "me@justinmccormick.com"
   },
   "main": "dist/index.js",
+  "exports": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
     "sg": "./dist/index.js",

--- a/packages/core/L3/nodejs/constructs/PackageJson.ts
+++ b/packages/core/L3/nodejs/constructs/PackageJson.ts
@@ -14,6 +14,7 @@ export interface NodePackageJsonProps {
   readonly repository?: string | { readonly type: string; readonly url: string };
   readonly keywords?: string[];
   readonly main?: string;
+  readonly exports?: Record<string, string>;
   readonly types?: string;
   readonly bin?: Record<string, string>;
   readonly scripts?: Record<string, string>;
@@ -37,6 +38,7 @@ const packageOrdering = [
   "bugs",
   "private",
   "main",
+  "exports",
   "types",
   "bin",
   "man",
@@ -76,6 +78,12 @@ export class PackageJson extends Manifest {
         repository: props.repository,
         keywords: props.keywords,
         main: props.main ?? `${project.buildPath}/index.js`,
+        exports:
+          // https://nodejs.org/api/packages.html#package-entry-points
+          props.exports ??
+          // fallback to exports sugar with a single option
+          // https://nodejs.org/api/packages.html#exports-sugar
+          `${project.buildPath}/index.js`,
         bin: props.bin,
         scripts: props.scripts,
         bugs: props.bugs,

--- a/packages/core/L3/nodejs/project/YarnMonoWorkspace.ts
+++ b/packages/core/L3/nodejs/project/YarnMonoWorkspace.ts
@@ -48,6 +48,7 @@ export class YarnMonoWorkspace extends YarnWorkspace {
        */
       packageFields.addShallowFields({
         bin: undefined,
+        exports: undefined,
         files: undefined,
         main: undefined,
         types: undefined,

--- a/packages/core/L3/nodejs/project/YarnMonoWorkspace.ts
+++ b/packages/core/L3/nodejs/project/YarnMonoWorkspace.ts
@@ -1,5 +1,5 @@
 import { Construct } from "constructs";
-import { IProject, LifeCycle, LifeCycleStage, Fields, Project } from "../../../L1";
+import { IProject, Fields, LifeCycle, LifeCycleStage, Project } from "../../../L1";
 import { ManifestEntry } from "../../../L2";
 import { NodeProject } from "./NodeProject";
 import { NodeWorkspaceProps } from "./NodeWorkspace";
@@ -23,6 +23,21 @@ export class YarnMonoWorkspace extends YarnWorkspace {
 
     const defaultProject = new YarnProject(this, "Default", { ...props, name: props?.name ?? "workspace" });
     this.defaultProject = defaultProject;
+
+    LifeCycle.of(defaultProject.packageJson).on(LifeCycleStage.BEFORE_WRITE, () => {
+      const packageFields = Fields.of(defaultProject.packageJson);
+
+      /**
+       * Removes fields related to package publishing from private packages that are not
+       * meant to be published.
+       */
+      packageFields.addShallowFields({
+        bin: undefined,
+        files: undefined,
+        main: undefined,
+        types: undefined,
+      });
+    });
 
     LifeCycle.of(defaultProject.packageJson).on(LifeCycleStage.BEFORE_WRITE, () => {
       const packageFields = Fields.of(defaultProject.packageJson);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,7 @@
     "email": "me@justinmccormick.com"
   },
   "main": "dist/index.js",
+  "exports": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "yalc": "npx yalc publish",


### PR DESCRIPTION
- Adds support for `exports`, but only a basic one. There are advanced options available, where additional sub-props can be provided for exports. E.g. `types`, `import`, and `require`. This is currently not implemened.
- We will need to re-run synth after #3 is merged, as the paths will be updated. In addition, a prefix `./` needs to be added explicitly for the default.

**NOTE**: Adding this breaks Yarn functionality, and I do not have any solutions to that yet.

Yarn will always explode with:

```
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target "././index.js" defined in the package config ..../stackgen/node_modules/@stackgen/core/package.json
```

If `exports` files do not exist. But if they _do_ exist, then Node will prefer them, over the source files. Any ideas on how to use source files in development, and override Yarn and not allow it to complain?

Closes: STA-22

---

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing guide?](https://github.com/StackBakery/stackgen/blob/master/CONTRIBUTING.md)

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
